### PR TITLE
G1: added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Currently `nosetests` need to run with several arguments.

Add these common arguments to the `setup.cfg` for documentation and ease-of-use.
